### PR TITLE
Normalize and sort enabled APIs to avoid duplicate entries

### DIFF
--- a/src/main/java/com/example/weatherapi/services/impl/WeatherServiceImpl.java
+++ b/src/main/java/com/example/weatherapi/services/impl/WeatherServiceImpl.java
@@ -150,7 +150,7 @@ public class WeatherServiceImpl implements WeatherService {
     }
 
     public Weather getWeatherMergedCustomApis(String cityName, List<String> enabledApis) {
-        enabledApis = enabledApis.stream().map(String::toUpperCase).toList();
+        enabledApis = enabledApis.stream().map(String::toUpperCase).sorted().toList();
         String key = cityName.toLowerCase() + "custom_" + String.join("_", enabledApis);
 
         Weather weatherFromCache = Objects.requireNonNull(cacheManager.getCache(cacheName)).get(key, Weather.class);


### PR DESCRIPTION
Sorted api's so we always have an order to them to avoid duplicate caches / db saves